### PR TITLE
Support for local, build-only extensions which are removed on deployment

### DIFF
--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -18,7 +18,7 @@ def build(pod_path, out_dir):
   pod.preprocess()
   try:
     if 'buildsuffix' in pod.flags:
-      paths_to_contents = pod.dump(suffix=pod.flags['buildsuffix'])
+      paths_to_contents = pod.dump(buildsuffix=pod.flags['buildsuffix'])
     else:
       paths_to_contents = pod.dump()
     repo = utils.get_git_repo(pod.root)

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -17,8 +17,8 @@ def build(pod_path, out_dir):
   pod = pods.Pod(root, storage=storage.FileStorage)
   pod.preprocess()
   try:
-    if 'suffix' in pod.flags:
-      paths_to_contents = pod.dump(suffix=pod.flags['suffix'])
+    if 'buildsuffix' in pod.flags:
+      paths_to_contents = pod.dump(suffix=pod.flags['buildsuffix'])
     else:
       paths_to_contents = pod.dump()
     repo = utils.get_git_repo(pod.root)

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -17,7 +17,10 @@ def build(pod_path, out_dir):
   pod = pods.Pod(root, storage=storage.FileStorage)
   pod.preprocess()
   try:
-    paths_to_contents = pod.dump()
+    if 'suffix' in pod.flags:
+      paths_to_contents = pod.dump(suffix=pod.flags['suffix'])
+    else:
+      paths_to_contents = pod.dump()
     repo = utils.get_git_repo(pod.root)
     config = local_destination.Config(out_dir=out_dir)
     stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)

--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -35,7 +35,10 @@ def deploy(deployment_name, pod_path, build, confirm, test, test_only, auth):
     if test_only:
       deployment.test()
       return
-    paths_to_contents = pod.dump()
+    if 'buildsuffix' in pod.flags:
+      paths_to_contents = pod.dump(buildsuffix=pod.flags['buildsuffix'])
+    else:
+      paths_to_contents = pod.dump()
     repo = utils.get_git_repo(pod.root)
     stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
     deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,

--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -45,7 +45,10 @@ class AmazonS3Destination(base.BaseDestination):
     path = os.path.join(self.control_dir, path.lstrip('/'))
     return self.write_file(path, content, policy='private')
 
-  def read_file(self, path):
+  def read_file(self, path, buildsuffix=''):
+    if buildsuffix:
+      if path.endswith(buildsuffix):
+        path = path[:-len(buildsuffix)]
     file_key = key.Key(self.bucket)
     file_key.key = path
     try:
@@ -55,12 +58,15 @@ class AmazonS3Destination(base.BaseDestination):
         raise
       raise IOError('File not found: {}'.format(path))
 
-  def delete_file(self, path):
+  def delete_file(self, path, buildsuffix=''):
+    if buildsuffix:
+      if path.endswith(buildsuffix):
+        path = path[:-len(buildsuffix)]
     bucket_key = key.Key(self.bucket)
     bucket_key.key = path.lstrip('/')
     self.bucket.delete_key(bucket_key)
 
-  def write_file(self, path, content, policy='public-read'):
+  def write_file(self, path, content, policy='public-read', buildsuffix=''):
     path = path.lstrip('/')
     if isinstance(content, unicode):
       content = content.encode('utf-8')
@@ -73,6 +79,9 @@ class AmazonS3Destination(base.BaseDestination):
     headers = {'Cache-Control': 'no-cache'}
     if mimetype:
       headers['Content-Type'] = mimetype
+    if buildsuffix:
+      if path.endswith(buildsuffix):
+        bucket_key.key = path[:-len(buildsuffix)]
     fp.seek(0)
     bucket_key.set_contents_from_file(fp, headers=headers, replace=True, policy=policy)
     fp.close()

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -149,14 +149,14 @@ class BaseDestination(object):
     config = env.EnvConfig(host='localhost')
     return env.Env(config)
 
-  def read_file(self, path):
+  def read_file(self, path, buildsuffix=''):
     """Returns a file-like object."""
     raise NotImplementedError
 
-  def write_file(self, path, content):
+  def write_file(self, path, content, buildsuffix=''):
     raise NotImplementedError
 
-  def delete_file(self, path):
+  def delete_file(self, path, buildsuffix=''):
     raise NotImplementedError
 
   def delete_control_file(self, path):
@@ -218,6 +218,10 @@ class BaseDestination(object):
         return
       if dry_run:
         return
+      buildsuffix = ''
+      if stats is not None:
+        if 'buildsuffix' in stats.pod.flags:
+          buildsuffix = stats.pod.flags['buildsuffix']
       indexes.Diff.pretty_print(diff)
       if confirm:
         text = 'Proceed to launch? -> {}'.format(self)
@@ -227,7 +231,7 @@ class BaseDestination(object):
       indexes.Diff.apply(
           diff, paths_to_contents, write_func=self.write_file,
           delete_func=self.delete_file, threaded=self.threaded,
-          batch_writes=self.batch_writes)
+          batch_writes=self.batch_writes, buildsuffix=buildsuffix)
       self.write_control_file(self.index_basename, indexes.Index.to_string(new_index))
       if stats is not None:
         self.write_control_file(self.stats_basename, stats.to_string())

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -21,15 +21,15 @@ class LocalDestination(base.BaseDestination):
   def __str__(self):
     return 'file://{}'.format(self.config.out_dir)
 
-  def read_file(self, path):
+  def read_file(self, path, buildsuffix=''):
     path = os.path.join(self.config.out_dir, path.lstrip('/'))
     return self.storage.read(path)
 
-  def delete_file(self, path):
+  def delete_file(self, path, buildsuffix=''):
     out_path = os.path.join(self.config.out_dir, path.lstrip('/'))
     self.storage.delete(out_path)
 
-  def write_file(self, path, content):
+  def write_file(self, path, content, buildsuffix=''):
     if isinstance(content, unicode):
       content = content.encode('utf-8')
     out_path = os.path.join(self.config.out_dir, path.lstrip('/'))

--- a/grow/deployments/indexes/indexes.py
+++ b/grow/deployments/indexes/indexes.py
@@ -155,7 +155,7 @@ class Diff(object):
 
   @classmethod
   def apply(cls, message, paths_to_content, write_func, delete_func, threaded=True,
-            batch_writes=False):
+            batch_writes=False, buildsuffix=''):
     # TODO(jeremydw): Thread pool for the threaded operation.
     diff = message
     threads = []
@@ -181,7 +181,7 @@ class Diff(object):
       for file_message in diff.adds:
         content = paths_to_content[file_message.path]
         thread = ProgressBarThread(
-            bar, True, target=write_func, args=(file_message.path, content))
+            bar, True, target=write_func, args=(file_message.path, content), kwargs={'buildsuffix': buildsuffix})
         threads.append(thread)
         thread.start()
         if not threaded:
@@ -189,14 +189,14 @@ class Diff(object):
       for file_message in diff.edits:
         content = paths_to_content[file_message.path]
         thread = ProgressBarThread(
-            bar, True, target=write_func, args=(file_message.path, content))
+            bar, True, target=write_func, args=(file_message.path, content), kwargs={'buildsuffix': buildsuffix})
         threads.append(thread)
         thread.start()
         if not threaded:
           thread.join()
       for file_message in diff.deletes:
         thread = ProgressBarThread(
-            bar, batch_writes, target=delete_func, args=(file_message.path,))
+            bar, batch_writes, target=delete_func, args=(file_message.path,), kwargs={'buildsuffix': buildsuffix})
         threads.append(thread)
         thread.start()
         if not threaded:

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -227,16 +227,17 @@ class Pod(object):
       output['/404.html'] = error_controller.render()
     return output
 
-  def dump(self, suffix='/index.html'):
+  def dump(self, buildsuffix=''):
     output = self.export()
     clean_output = {}
-    if suffix:
-      for path, content in output.iteritems():
-        if suffix and path.endswith('/') or '.' not in os.path.basename(path):
-          path = path.rstrip('/') + suffix
-        clean_output[path] = content
-    else:
-      clean_output = output
+    for path, content in output.iteritems():
+      if path.endswith('/'):
+        path = path + 'index.html'
+      if not buildsuffix and '.' not in os.path.basename(path):
+        path = path.rstrip('/') + '/' + 'index.html'
+      if buildsuffix and '.' not in os.path.basename(path):
+        path = path + buildsuffix
+      clean_output[path] = content
     return clean_output
 
   def to_message(self):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -227,13 +227,13 @@ class Pod(object):
       output['/404.html'] = error_controller.render()
     return output
 
-  def dump(self, suffix='index.html'):
+  def dump(self, suffix='/index.html'):
     output = self.export()
     clean_output = {}
     if suffix:
       for path, content in output.iteritems():
         if suffix and path.endswith('/') or '.' not in os.path.basename(path):
-          path = path.rstrip('/') + '/' + suffix
+          path = path.rstrip('/') + suffix
         clean_output[path] = content
     else:
       clean_output = output


### PR DESCRIPTION
Not expecting this to be merged as-is, but rather a starting point for a conversation.

Deploying to an object store like S3 means you don't have to stick with filesystem restrictions.  You can have an "about-us" URL without an extension and without a trailing slash, and also "about-us/image.gif" under it, because they're uniquely named objects, not files in a hierarchy.  See:

- http://vitorio-test-grow.s3-website-us-east-1.amazonaws.com/about-us
- http://vitorio-test-grow.s3-website-us-east-1.amazonaws.com/about-us/bench.gif

This works out of the box with the Grow development server, by changing the codelab's `content/pages/_blueprint.yaml`:

    path: /{slug}               # The URL path format.

And changing the codelab's main `podspec.yaml`:

    static_dirs:
      - static_dir: /static/
        serve_at: /static/
      - static_dir: /assets/about-us/
        serve_at: /about-us/

But, on build and deployment, it generates an "index.html" inside the "about-us" directory instead.  This is understandable, given the limitations of a filesystem, but what we really want is for "about-us" to live in the root as a file, not be a directory.

The code changes in this pull request add the concept of a build-only file extension that is removed upon deployment to a supported object store.  Adding this to `podspec.yaml` triggers the additional codepaths to generate "about-us.objstore.html" in the root, and then remove that `buildsuffix` when deploying:

    flags:
      buildsuffix: .objstore.html

I'm sure there's a better way to handle this, looking forward to your thoughts, feedback and critique.