### PR TITLE
Object store-specific temporary deployment extensions

### DIFF
--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -35,7 +35,15 @@ def deploy(deployment_name, pod_path, build, confirm, test, test_only, auth):
     if test_only:
       deployment.test()
       return
-    paths_to_contents = pod.dump()
+    build_extension = ''
+    try:
+      extensionless_paths = deployment.config.field_by_name('extensionless_paths')
+    except KeyError:
+      pass
+    else:
+      if deployment.config.extensionless_paths:
+        build_extension = deployment.config.build_extension
+    paths_to_contents = pod.dump(build_extension=build_extension)
     repo = utils.get_git_repo(pod.root)
     stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
     deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -227,16 +227,17 @@ class Pod(object):
       output['/404.html'] = error_controller.render()
     return output
 
-  def dump(self, suffix='index.html'):
+  def dump(self, main_page_suffix='index.html', build_extension=''):
     output = self.export()
     clean_output = {}
-    if suffix:
-      for path, content in output.iteritems():
-        if suffix and path.endswith('/') or '.' not in os.path.basename(path):
-          path = path.rstrip('/') + '/' + suffix
-        clean_output[path] = content
-    else:
-      clean_output = output
+    for path, content in output.iteritems():
+      if path.endswith('/'):
+        path = path.rstrip('/') + '/' + main_page_suffix
+      if not build_extension and '.' not in os.path.basename(path):
+        path = path.rstrip('/') + '/' + main_page_suffix
+      if build_extension and '.' not in os.path.basename(path):
+        path = path + build_extension
+      clean_output[path] = content
     return clean_output
 
   def to_message(self):


### PR DESCRIPTION
Hi, okay, after #64, it occurred to me that, if these temporary extensions are object store deployment-specific, and temporary, then they should probably have their scope limited to deployment, both in code and configuration, and the user shouldn't really have to deal with them otherwise.

As with #64, this pull request supports deploying resources to an object store (like S3) without extensions, by building on the filesystem with a temporary extension and then removing it on `write_file`, while also still supporting subresources, as seen here:

 - http://vitorio-test-grow.s3-website-us-east-1.amazonaws.com/about-us
 - http://vitorio-test-grow.s3-website-us-east-1.amazonaws.com/about-us/bench.gif

(That deployment is new, using this code, not using #64's code.)

This is already supported using the built in `grow run` development server with a `_blueprint.yaml` of:

    path: /{slug}               # The URL path format

And a `podspec.yaml` including:

    static_dirs:
      - static_dir: /static/
        serve_at: /static/
      - static_dir: /assets/about-us/
        serve_at: /about-us/

This new pull request enables a new configuration option only in the S3 deployment code:

    deployments:
      default:
        destination: local
        out_dir: my-codelab-launch/
      s3:
        destination: s3
        bucket: vitorio-test-grow
        extensionless_paths: yes

(By default, `extensionless_paths` is "no", and not needed to be specified at all.  There is also an option to specify the temporary extension used, but a reasonable default is also provided.)

No other deployment destinations are affected.  `extensionless_paths` is trapped appropriately in `deploy.py` for destinations which do not support it.  The `dump` function in `pods.py` is made more explicit to support both `index.html` and temporary extensions, and `suffix` is renamed to `main_page_suffix` to match `google_cloud_storage.py`.

I hope you'll consider accepting this pull request.  I'm also idling in IRC if you'd like to discuss it further there.