### PR TITLE
Add ability to configure trailing slash redirect behavior

### DIFF
--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -17,11 +17,11 @@ def build(pod_path, out_dir):
   pod = pods.Pod(root, storage=storage.FileStorage)
   pod.preprocess()
   try:
-    paths_to_contents = pod.dump()
-    repo = utils.get_git_repo(pod.root)
     config = local_destination.Config(out_dir=out_dir)
-    stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
     destination = local_destination.LocalDestination(config)
+    paths_to_contents = destination.dump(pod)
+    repo = utils.get_git_repo(pod.root)
+    stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
     destination.deploy(paths_to_contents, stats=stats_obj, repo=repo, confirm=False,
                        test=False)
   except pods.Error as e:

--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -30,12 +30,10 @@ def deploy(deployment_name, pod_path, build, confirm, test, test_only, auth):
       deployment.login(auth)
     if build:
       pod.preprocess()
-    # Set the environment information for the pod based on the deployment.
-    pod.env = deployment.get_env()
     if test_only:
       deployment.test()
       return
-    paths_to_contents = pod.dump()
+    paths_to_contents = deployment.dump(pod)
     repo = utils.get_git_repo(pod.root)
     stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
     deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,

--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -17,6 +17,10 @@ class Config(messages.Message):
   access_secret = messages.StringField(3)
   env = messages.MessageField(env.EnvConfig, 4)
   keep_control_dir = messages.BooleanField(5, default=False)
+  redirect_trailing_slashes = messages.BooleanField(6, default=True)
+  index_document = messages.StringField(7, default='index.html')
+  error_document = messages.StringField(8, default='404.html')
+
 
 
 class AmazonS3Destination(base.BaseDestination):
@@ -33,13 +37,21 @@ class AmazonS3Destination(base.BaseDestination):
         calling_format=connection.OrdinaryCallingFormat())
     return boto_connection.get_bucket(self.config.bucket)
 
+  def dump(self, pod):
+    pod.env = self.get_env()
+    return pod.dump(
+        suffix=self.config.index_document,
+        append_slashes=self.config.redirect_trailing_slashes)
+
   def prelaunch(self, dry_run=False):
     if dry_run:
       return
     logging.info('Configuring S3 bucket: {}'.format(self.config.bucket))
     self.bucket.set_acl('public-read')
     self.bucket.configure_versioning(False)
-    self.bucket.configure_website('index.html', '404.html')
+    self.bucket.configure_website(
+        self.config.index_document,
+        self.config.error_document)
 
   def write_control_file(self, path, content):
     path = os.path.join(self.control_dir, path.lstrip('/'))
@@ -62,17 +74,19 @@ class AmazonS3Destination(base.BaseDestination):
 
   def write_file(self, path, content, policy='public-read'):
     path = path.lstrip('/')
+    path = path if path != '' else self.config.index_document
     if isinstance(content, unicode):
       content = content.encode('utf-8')
     bucket_key = key.Key(self.bucket)
     bucket_key.key = path
     fp = cStringIO.StringIO()
     fp.write(content)
-    # TODO(jeremydw): Better headers.
     mimetype = mimetypes.guess_type(path)[0]
-    headers = {'Cache-Control': 'no-cache'}
-    if mimetype:
-      headers['Content-Type'] = mimetype
+    # TODO: Allow configurable headers.
+    headers = {
+        'Cache-Control': 'no-cache',
+        'Content-Type': mimetype if mimetype else 'text/html',
+    }
     fp.seek(0)
     bucket_key.set_contents_from_file(fp, headers=headers, replace=True, policy=policy)
     fp.close()

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -200,6 +200,10 @@ class BaseDestination(object):
   def login(self, account, reauth=False):
     pass
 
+  def dump(self, pod):
+    pod.env = self.get_env()
+    return pod.dump()
+
   def deploy(self, paths_to_contents, stats=None, repo=None, dry_run=False, confirm=False,
              test=True):
     self.prelaunch(dry_run=dry_run)

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -9,7 +9,6 @@ from protorpc import messages
 import boto
 import cStringIO
 import dns.resolver
-import logging
 import mimetypes
 import os
 import webapp2
@@ -55,6 +54,9 @@ class Config(messages.Message):
   key_path = messages.StringField(6)
   env = messages.MessageField(env.EnvConfig, 7)
   keep_control_dir = messages.BooleanField(8, default=False)
+  redirect_trailing_slashes = messages.BooleanField(9, default=True)
+  main_page_suffix = messages.StringField(10, default='index.html')
+  not_found_page = messages.StringField(11, default='404.html')
 
 
 class GoogleCloudStorageDestination(base.BaseDestination):
@@ -84,19 +86,28 @@ class GoogleCloudStorageDestination(base.BaseDestination):
           self.config.project, self.config.email, self.config.key_path)
     return gs_connection.get_bucket(self.config.bucket)
 
+  def dump(self, pod):
+    pod.env = self.get_env()
+    return pod.dump(
+        suffix=self.config.main_page_suffix,
+        append_slashes=self.config.redirect_trailing_slashes)
+
   def prelaunch(self, dry_run=False):
     if dry_run:
       return
-    logging.info('Configuring GS bucket: {}'.format(self.config.bucket))
     if self.use_interoperable_auth:
       self.bucket.set_acl('public-read')
       self.bucket.configure_versioning(False)
-      self.bucket.configure_website(main_page_suffix='index.html', error_key='404.html')
+      self.bucket.configure_website(
+          main_page_suffix=self.config.main_page_suffix,
+          error_key=self.config.not_found_page)
     else:
       acl = self.bucket.get_default_object_acl()
       acl.all().grant_read().revoke_write()
       acl.save()
-      self.bucket.configure_website(main_page_suffix='index.html', not_found_page='404.html')
+      self.bucket.configure_website(
+          main_page_suffix=self.config.main_page_suffix,
+          not_found_page=self.config.not_found_page)
 
   def write_control_file(self, path, content):
     path = os.path.join(self.control_dir, path.lstrip('/'))
@@ -134,18 +145,20 @@ class GoogleCloudStorageDestination(base.BaseDestination):
     if isinstance(content, unicode):
       content = content.encode('utf-8')
     path = path.lstrip('/')
-    mimetype = mimetypes.guess_type(path)[0]
+    path = path if path != '' else self.config.main_page_suffix
+    mimetype = mimetypes.guess_type(path)[0] or 'text/html'
     fp = cStringIO.StringIO()
     fp.write(content)
     size = fp.tell()
-
     try:
       if self.use_interoperable_auth:
         file_key = key.Key(self.bucket)
         file_key.key = path
-        headers = {'Cache-Control': 'no-cache'}  # TODO(jeremydw): Better headers.
-        if mimetype:
-          headers['Content-Type'] = mimetype
+        # TODO: Allow configurable headers.
+        headers = {
+            'Cache-Control': 'no-cache',
+            'Content-Type': mimetype,
+        }
         file_key.set_contents_from_file(fp, headers=headers, replace=True, policy=policy,
                                         size=size, rewind=True)
       else:

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -9,6 +9,7 @@ from protorpc import messages
 import boto
 import cStringIO
 import dns.resolver
+import logging
 import mimetypes
 import os
 import webapp2
@@ -95,6 +96,7 @@ class GoogleCloudStorageDestination(base.BaseDestination):
   def prelaunch(self, dry_run=False):
     if dry_run:
       return
+    logging.info('Configuring GCS bucket: {}'.format(self.config.bucket))
     if self.use_interoperable_auth:
       self.bucket.set_acl('public-read')
       self.bucket.configure_versioning(False)

--- a/grow/pods/controllers/tags/builtins.py
+++ b/grow/pods/controllers/tags/builtins.py
@@ -68,10 +68,6 @@ def static(path, _pod=None):
   return path
 
 
-def get_doc(pod_path, locale=None, _pod=None):
-  return _pod.routes.get_doc(pod_path, locale=locale)
-
-
 class Menu(object):
 
   def __init__(self):
@@ -105,6 +101,10 @@ def breadcrumb(doc, _pod=None):
 def url(pod_path, locale=None, _pod=None):
   doc = _pod.get_doc(pod_path, locale=locale)
   return doc.url
+
+
+def get_doc(pod_path, locale=None, _pod=None):
+  return _pod.get_doc(pod_path, locale=locale)
 
 
 @jinja2.contextfilter

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -232,7 +232,9 @@ class Pod(object):
     clean_output = {}
     if suffix:
       for path, content in output.iteritems():
-        if append_slashes and not path.endswith('/'):
+        if (append_slashes
+            and not path.endswith('/')
+            and not os.path.splitext(path)[-1]):
           path = path.rstrip('/') + '/'
         if append_slashes and path.endswith('/') and suffix:
           path += suffix

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -227,13 +227,15 @@ class Pod(object):
       output['/404.html'] = error_controller.render()
     return output
 
-  def dump(self, suffix='index.html'):
+  def dump(self, suffix='index.html', append_slashes=True):
     output = self.export()
     clean_output = {}
     if suffix:
       for path, content in output.iteritems():
-        if suffix and path.endswith('/') or '.' not in os.path.basename(path):
-          path = path.rstrip('/') + '/' + suffix
+        if append_slashes and not path.endswith('/'):
+          path = path.rstrip('/') + '/'
+        if append_slashes and path.endswith('/') and suffix:
+          path += suffix
         clean_output[path] = content
     else:
       clean_output = output

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -38,7 +38,37 @@ class PodTest(unittest.TestCase):
     self.pod.export()
 
   def test_dump(self):
-    self.pod.dump()
+    paths = [
+        '/about/index.html',
+        '/contact-us/index.html',
+        '/de/about/index.html',
+        '/de/contact-us/index.html',
+        '/de/home/index.html',
+        '/de/html/index.html',
+        '/de/intro/index.html',
+        '/fr/about/index.html',
+        '/fr/contact-us/index.html',
+        '/fr/home/index.html',
+        '/fr/html/index.html',
+        '/fr/intro/index.html',
+        '/html/index.html',
+        '/index.html',
+        '/intro/index.html',
+        '/it/about/index.html',
+        '/it/contact-us/index.html',
+        '/it/home/index.html',
+        '/it/html/index.html',
+        '/it/intro/index.html',
+        '/post/newer/index.html',
+        '/post/newest/index.html',
+        '/post/older/index.html',
+        '/post/oldest/index.html',
+        '/public/file.txt',
+        '/public/main.css',
+        '/public/main.min.js',
+    ]
+    result = self.pod.dump()
+    self.assertItemsEqual(paths, result)
 
   def test_to_message(self):
     self.pod.to_message()

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,5 +41,3 @@ keyring>=2.1
 # Testing.
 nose==1.3.1
 rednose==0.4.1
-
-git+git://github.com/pyinstaller/pyinstaller.git@develop


### PR DESCRIPTION
Here's a pull request that's an alternative implementation to #65.

A few high-level notes:
* I realized that Grow *already* has a way to specify whether a resource should be served at a path with a trailing slash or not. This configuration is specified in a content file's frontmatter or blueprint. Here's an example: https://github.com/jeremydw/grow-redirect-slashes-demo/blob/master/content/pages/about.html – this makes the problem in #65 much more about how Grow configures trailing slash behavior for object stores rather than how Grow builds filesets.
* When a pod is deployed, we should follow this configuration as best we can. This means for object store deployments (S3 and GCS) – ones that allow objects and directories to share the same basename – we can deploy resources with a configuration following exactly what the user has specified. (Local deployments, where objects and directories cannot share the same name, use the "suffix" configuration.)
* In the current version of Grow,  there is no way for the developer to specify trailing slash behavior for object store deployments.

This patch adds a way for the developer to control trailing slash behavior, *independently* of how resources are built by Grow. This matches werkzeug's `strict_slashes` parameter (http://werkzeug.pocoo.org/docs/0.10/routing/#maps-rules-and-adapters) or Django's `APPEND_SLASH` (https://docs.djangoproject.com/en/1.7/ref/settings/#append-slash).

In this patch, when a developer configures an object store deployment with `redirect_trailing_slashes: true` – any "leaf" resource (that is, any resource whose path doesn't end in a trailing slash) will be redirected using the object store's built-in redirect rule (for GCS, this redirects to `$PATH/$MAIN_PAGE_SUFFIX`). `redirect_trailing_slashes: true` is the current default behavior of Grow.

If a developer specifies `redirect_trailing_slashes: false` – resources will be deployed to the object store exactly as they're specified in the pod's configuration. This means when a user visits a path `/foo`, that resource will only be served if it exists. `/foo/` causes a 404, as does `/foo/index.html` (for example).

Here's a sample pod that demonstrates this configuration:
https://github.com/jeremydw/grow-redirect-slashes-demo

With `redirect_trailing_slashes: false` (new behavior):
http://slashes-off.growlaunches.com/about-us (serves)
http://slashes-off.growlaunches.com/about-us/nested (serves)
http://slashes-off.growlaunches.com/about-us/ (404s)
http://slashes-off.growlaunches.com/about-us/index.html (404s)

With `redirect_trailing_slashes: true` (current/default behavior):
http://slashes-off.growlaunches.com/about-us (redirects)
http://slashes-off.growlaunches.com/about-us/ (serves)
http://slashes-off.growlaunches.com/about-us/index.html (serves)

@vitorio – sorry for sitting on this so long, but I wanted to think this through, and I knew that we already had a way to specify whether or not a path should have a trailing slash or not. This configuration format matches Jinja2's and Django's configuration options, which I'm happy about.

What do you think? Does this meet your needs? Thanks!