### PR TITLE
Set `zip_safe` to false so that we can install pygrow from source.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     ),
     long_description=open('description.txt').read().strip(),
     url='https://growsdk.org',
+    zip_safe=False,
     license='MIT',
     author='Grow SDK Authors',
     author_email='hello@grow.io',


### PR DESCRIPTION
At the moment it tries to access the filesystem but can't as the files are inside the zipped egg.