### PR TITLE
Update README pip install gotchas for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ Once installed, you can...
     ./scripts/test                                 # Runs tests.
     ./scripts/grow                                 # Runs `grow` command line program.
 
-#### Gotchas
-
-From a fresh system, you may need a few things to build a Grow release from scratch:
-
-    sudo apt-get install python-dev python-pip libffi-dev g++ git libxml2-dev libxslt-dev libssl-dev zip
-    sudo pip install pyinstaller
-
 #### Installation alternatives
 
     # Installs Grow in Python's site-packages directory.
@@ -86,6 +79,19 @@ From a fresh system, you may need a few things to build a Grow release from scra
     cd pygrow
     pip install -r requirements.txt
     python setup.py install
+
+#### Linux gotchas (Ubuntu)
+
+From a fresh system, you may need a few things to build a Grow release from scratch:
+
+```bash
+sudo apt-get install python python-pip build-essential python-all-dev zip \
+  libc6 libyaml-dev libffi-dev libxml2-dev libxslt-dev libssl-dev zip
+sudo pip install --upgrade pip
+sudo pip install --upgrade six
+
+sudo pip install grow
+```
 
 ### Running tests
 


### PR DESCRIPTION
@jeremydw for review

Installing grow from pip on a blank Ubuntu install fails on two dependencies:
<img width="1269" alt="screen shot 2015-08-13 at 12 31 06 pm" src="https://cloud.githubusercontent.com/assets/75300/9260158/df26b6e2-41ba-11e5-88b5-0df9f2995b85.png">
<img width="951" alt="screen shot 2015-08-13 at 12 39 49 pm" src="https://cloud.githubusercontent.com/assets/75300/9260163/e202c2de-41ba-11e5-82ce-d2c217e01947.png">

Unfortunately you have to upgrade the "six" package independent of the other steps.

Also, pip apparently only has 0.0.52, not the latest 0.0.53 release.