### PR TITLE
Implement fingerprint path formatter for static assets.

### DIFF
--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -124,6 +124,7 @@ class BaseDestination(object):
     self.name = name
     self.pod = None
     self._diff = None
+    self._confirm = None
 
   def __str__(self):
     return self.__class__.__name__
@@ -219,6 +220,7 @@ class BaseDestination(object):
 
   def deploy(self, paths_to_contents, stats=None, repo=None, dry_run=False, confirm=False,
              test=True):
+    self._confirm = confirm
     self.prelaunch(dry_run=dry_run)
     if test:
       self.test()

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -58,9 +58,10 @@ class WebReviewDestination(base.BaseDestination):
       try:
         self.webreview.commit = utils.create_commit_message(repo)
       except ValueError:
-        raise ValueError(
-            'Cannot deploy to WebReview from a Git repository without a HEAD.'
-            ' Commit first then deploy to WebReview.')
+        raise
+#        raise ValueError(
+#            'Cannot deploy to WebReview from a Git repository without a HEAD.'
+#            ' Commit first then deploy to WebReview.')
     result = super(WebReviewDestination, self).deploy(*args, **kwargs)
     if self.success:
       finalize_response = self.webreview.finalize()

--- a/grow/deployments/indexes/indexes.py
+++ b/grow/deployments/indexes/indexes.py
@@ -153,7 +153,8 @@ class Diff(object):
           and index.commit and index.commit.sha):
       diff.what_changed = repo.git.log(
           '--date=short',
-          '--pretty=format:[%h] %ad <%ae> %s').decode('utf-8')
+          '--pretty=format:[%h] %ad <%ae> %s')
+#      .decode('utf-8')
 
     return diff
 

--- a/grow/pods/controllers/static.py
+++ b/grow/pods/controllers/static.py
@@ -73,11 +73,11 @@ class StaticFile(object):
 
   @staticmethod
   def _create_fingerprint(pod, pod_path):
-    sha = hashlib.sha1()
+    md5 = hashlib.md5()
     with pod.open_file(pod_path, 'rb') as fp:
       content = fp.read()
-      sha.update(content)
-    return sha.hexdigest()
+      md5.update(content)
+    return md5.hexdigest()
 
   @property
   def url(self):
@@ -220,7 +220,10 @@ class StaticController(base.BaseController):
         if match:
           kwargs = match.groupdict()
           kwargs['root'] = self.pod.podspec.root
-          kwargs['fingerprint'] = 'foo'
+          if 'fingerprint' in self.path_format:
+            pod_path = os.path.join(source, kwargs['filename'])
+            fingerprint = StaticFile._create_fingerprint(self.pod, pod_path)
+            kwargs['fingerprint'] = fingerprint
           if 'locale' in kwargs:
             normalized_locale = self.pod.normalize_locale(kwargs['locale'])
             kwargs['locale'] = (

--- a/grow/pods/controllers/static.py
+++ b/grow/pods/controllers/static.py
@@ -221,8 +221,7 @@ class StaticController(base.BaseController):
           kwargs = match.groupdict()
           kwargs['root'] = self.pod.podspec.root
           if 'fingerprint' in self.path_format:
-            pod_path = os.path.join(source, kwargs['filename'])
-            fingerprint = StaticFile._create_fingerprint(self.pod, pod_path)
+            fingerprint = StaticFile._create_fingerprint(self.pod, path)
             kwargs['fingerprint'] = fingerprint
           if 'locale' in kwargs:
             normalized_locale = self.pod.normalize_locale(kwargs['locale'])

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -104,6 +104,7 @@ class PodTest(unittest.TestCase):
         '/public/main.min.js',
         '/root/base/index.html',
         '/root/static/file.txt',
+        '/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
         '/yaml_test/index.html',
     ]
     result = self.pod.dump()

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -104,7 +104,8 @@ class PodTest(unittest.TestCase):
         '/public/main.min.js',
         '/root/base/index.html',
         '/root/static/file.txt',
-        '/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
+        '/root/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/de_alias/fingerprinted.txt',
+        '/root/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
         '/yaml_test/index.html',
     ]
     result = self.pod.dump()

--- a/grow/pods/routes.py
+++ b/grow/pods/routes.py
@@ -92,6 +92,7 @@ class Routes(object):
     if 'root' in self.podspec:
       path = path.replace('{root}', self.podspec['root'])
     path = path.replace('{env.fingerprint}', self.pod.env.fingerprint)
+    path = path.replace('{fingerprint}', '<grow:fingerprint>')
     path = path.replace('//', '/')
     return path
 
@@ -148,6 +149,8 @@ class Routes(object):
       routing.RequestRedirect: When the controller is a redirect.
       routing.NotFound: When no controller is found.
     """
+    if '/..' in path:
+      raise webob.exc.HTTPBadRequest('Invalid path.')
     urls = self.routing_map.bind_to_environ(env)
     try:
       controller, route_params = urls.match(path)

--- a/grow/pods/routes_test.py
+++ b/grow/pods/routes_test.py
@@ -80,6 +80,7 @@ class RoutesTest(unittest.TestCase):
         '/public/main.min.js',
         '/root/base/',
         '/root/static/file.txt',
+        '/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
         '/yaml_test/',
     ]
     result = self.pod.routes.list_concrete_paths()

--- a/grow/pods/routes_test.py
+++ b/grow/pods/routes_test.py
@@ -80,7 +80,8 @@ class RoutesTest(unittest.TestCase):
         '/public/main.min.js',
         '/root/base/',
         '/root/static/file.txt',
-        '/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
+        '/root/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/de_alias/fingerprinted.txt',
+        '/root/static-fingerprint/961109f2e6cc139a8f6df6e3a307c247/fingerprinted.txt',
         '/yaml_test/',
     ]
     result = self.pod.routes.list_concrete_paths()

--- a/grow/server/manager.py
+++ b/grow/server/manager.py
@@ -13,6 +13,10 @@ import twisted
 import webbrowser
 
 
+def shutdown(pod):
+  pod.logger.info('Goodbye. Shutting down.')
+
+
 def start(pod, host=None, port=None, open_browser=False, debug=False,
           preprocess=True):
   observer, podspec_observer = file_watchers.create_dev_server_observers(pod)
@@ -27,8 +31,9 @@ def start(pod, host=None, port=None, open_browser=False, debug=False,
   url = print_server_ready_message(pod, host, port)
   if open_browser:
     start_browser(url)
+  shutdown_func = lambda *args: shutdown(pod)
+  reactor.addSystemEventTrigger('during', 'shutdown', shutdown_func)
   reactor.run()
-  pod.logger.info('Goodbye. Shutting down.')
 
 
 def find_port_and_start_server(pod, host, port, debug):

--- a/grow/testing/testdata/pod/podspec.yaml
+++ b/grow/testing/testdata/pod/podspec.yaml
@@ -7,7 +7,10 @@ flags:
 
 static_dirs:
 - static_dir: /static-fingerprint/
-  serve_at: "/static-fingerprint/{fingerprint}/"
+  serve_at: "/{root}/static-fingerprint/{fingerprint}/"
+  localization:
+    static_dir: /static-fingerprint/intl/{locale}/
+    serve_at: /{root}/static-fingerprint/{fingerprint}/{locale}/
 - static_dir: /static-root/
   serve_at: "/{root}/static/"
 - static_dir: /static/

--- a/grow/testing/testdata/pod/podspec.yaml
+++ b/grow/testing/testdata/pod/podspec.yaml
@@ -6,6 +6,8 @@ flags:
   static_dir: /public/
 
 static_dirs:
+- static_dir: /static-fingerprint/
+  serve_at: "/static-fingerprint/{fingerprint}/"
 - static_dir: /static-root/
   serve_at: "/{root}/static/"
 - static_dir: /static/

--- a/grow/testing/testdata/pod/static-fingerprint/fingerprinted.txt
+++ b/grow/testing/testdata/pod/static-fingerprint/fingerprinted.txt
@@ -1,0 +1,1 @@
+fingerprinted

--- a/grow/testing/testdata/pod/static-fingerprint/intl/de/fingerprinted.txt
+++ b/grow/testing/testdata/pod/static-fingerprint/intl/de/fingerprinted.txt
@@ -1,0 +1,1 @@
+fingerprinted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel==1.3
-GitPython==0.3.2.RC1
+GitPython==1.0.1
 GoogleAppEngineCloudStorageClient==1.9.5.0
 Jinja2==2.8
 Markdown==2.4


### PR DESCRIPTION
Hi @meizon -- support for fingerprints is in `feature/fingerprint`.

If you'd like -- give this a try by building from source. Use `{fingerprint}` in the `serve_at` path formatter to use it. The fingerprint is an md5 hash of the file's contents. Let me know on Hangouts if this looks good, thanks!