### PR TITLE
Changed messages associated with 'grow run' command to logging messages

### DIFF
--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -56,11 +56,11 @@ def check_for_sdk_updates(auto_update_prompt=False):
     if theirs <= yours:
         return
     url = 'https://github.com/grow/pygrow/releases/tag/{}'.format(theirs)
-    print ''
-    print '  Please update to the newest version of the Grow SDK.'
-    print '  See release notes: {}'.format(url)
-    print '  Your version: {}, latest version: {}'.format(
-        colorize(yours, ansi=226), colorize(theirs, ansi=82))
+    logging.info('')
+    logging.info('  Please update to the newest version of the Grow SDK.')
+    logging.info('  See release notes: {}'.format(url))
+    logging.info('  Your version: {}, latest version: {}'.format(
+        colorize(yours, ansi=226), colorize(theirs, ansi=82)))
     if utils.is_packaged_app() and auto_update_prompt:
         # If the installation was successful, restart the process.
         try:
@@ -75,5 +75,5 @@ def check_for_sdk_updates(auto_update_prompt=False):
             logging.error(text)
             sys.exit(-1)
     else:
-        print '  Update using: ' + colorize('pip install --upgrade grow', ansi=200)
+        logging.info('  Update using: ' + colorize('pip install --upgrade grow', ansi=200))
     print ''

--- a/grow/server/manager.py
+++ b/grow/server/manager.py
@@ -64,9 +64,9 @@ def print_server_ready_message(pod, host, port):
     else:
         root_path = pod.get_root_path()
     url = 'http://{}:{}{}'.format(host, port, root_path)
-    print 'Pod: '.rjust(20) + pod.root
-    print 'Address: '.rjust(20) + url
-    print colorize('Server ready. '.rjust(20), ansi=47) + 'Press ctrl-c to quit.'
+    pod.logger.info('Pod: '.rjust(20) + pod.root)
+    pod.logger.info('Address: '.rjust(20) + url)
+    pod.logger.info(colorize('Server ready. '.rjust(20), ansi=47) + 'Press ctrl-c to quit.')
     return url
 
 

--- a/grow/server/manager.py
+++ b/grow/server/manager.py
@@ -64,9 +64,9 @@ def print_server_ready_message(pod, host, port):
     else:
         root_path = pod.get_root_path()
     url = 'http://{}:{}{}'.format(host, port, root_path)
-    pod.logger.info('Pod: '.rjust(20) + pod.root)
-    pod.logger.info('Address: '.rjust(20) + url)
-    pod.logger.info(colorize('Server ready. '.rjust(20), ansi=47) + 'Press ctrl-c to quit.')
+    logging.info('Pod: '.rjust(20) + pod.root)
+    logging.info('Address: '.rjust(20) + url)
+    logging.info(colorize('Server ready. '.rjust(20), ansi=47) + 'Press ctrl-c to quit.')
     return url
 
 


### PR DESCRIPTION
I've updated a few things that were previously being printed to use logging instead, so that these messages are passed to stdout. 

In my specific use case, I'm using a gulp task to run the 'grow run' command via subprocess, and the `print` messages aren't passed into the stdout, so the task can't display the `print_server_ready_message` or 'check_for_sdk_updates` message. This change enables me to pass these notifications to the subprocess and display them along with the gulp output.