### PR TITLE
Add support for Jinja2 extensions and custom preprocessors (2)

### DIFF
--- a/grow/__init__.py
+++ b/grow/__init__.py
@@ -1,5 +1,8 @@
 import os
 import sys
 
+# Allow easy import for custom preprocessors: `from grow import Preprocessor`
+from grow.pods.preprocessors.base import BasePreprocessor as Preprocessor
+
 # Allows "import grow" and "from grow import <name>".
 sys.path.extend([os.path.join(os.path.dirname(__file__), '..')])

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -4,6 +4,7 @@ import csv as csv_lib
 import functools
 import gettext
 import git
+import imp
 import json
 import logging
 import os
@@ -246,3 +247,17 @@ def get_rows_from_csv(pod, path, locale=_no_locale):
             data[header] = cell.decode('utf-8')
         rows.append(data)
     return rows
+
+
+def import_string(import_name, paths):
+    """ Imports & returns an object using dot notation, e.g. 'A.B.C' """
+    # ASSUMPTION: import_name refers to a value in a module (i.e. must have at
+    # least 2 parts)
+    assert '.' in import_name
+    part1, part2 = import_name.split('.', 1)
+    if '.' in part2:
+        f, part1_path, desc = imp.find_module(part1, paths)
+        return import_string(part2, [part1_path])
+    else:
+        module = imp.load_module(part1, *imp.find_module(part1, paths))
+        return getattr(module, part2)

--- a/grow/pods/controllers/rendered_test.py
+++ b/grow/pods/controllers/rendered_test.py
@@ -32,6 +32,12 @@ class RenderedTest(unittest.TestCase):
         controller = self.pod.match('/fr/about/')
         controller.render()
 
+    def test_custom_jinja_extensions(self):
+        controller = self.pod.match('/')
+        result = controller.render()
+        # Test pod uses a custom `|triplicate` filter on 'abcabcabc'
+        self.assertIn('Custom Jinja Extension: abcabcabc', result)
+
     def test_list_concrete_paths(self):
         controller = self.pod.match('/')
         self.assertEqual(['/'], controller.list_concrete_paths())

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -359,6 +359,10 @@ class Pod(object):
 
     def list_preprocessors(self):
         results = []
+        preprocessors.register_extensions(
+            self.yaml.get('extensions', {}).get('preprocessors', []),
+            self.root,
+        )
         preprocessor_config = copy.deepcopy(self.yaml.get('preprocessors', []))
         for params in preprocessor_config:
             kind = params.pop('kind')

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -384,6 +384,19 @@ class Pod(object):
         client = werkzeug_cache.SimpleCache()
         return jinja2.MemcachedBytecodeCache(client=client)
 
+    def list_jinja_extensions(self):
+        extensions = []
+        for name in self.yaml.get('extensions', {}).get('jinja2', []):
+            try:
+                value = utils.import_string(name, [self.root])
+            except:
+                raise PodSpecParseError(
+                    'Could not import {}: must use dot syntax relative to the pod root'
+                    .format(repr(name))
+                )
+            extensions.append(value)
+        return extensions
+
     @utils.memoize
     def create_template_env(self, locale=None, root=None):
         # NOTE: The template environment cannot be reused across locales, since
@@ -406,6 +419,7 @@ class Pod(object):
             kwargs['bytecode_cache'] = self._get_bytecode_cache()
         if self.podspec.flags.get('compress_html'):
             kwargs['extensions'].append(jinja2htmlcompress.HTMLCompress)
+        kwargs['extensions'].extend(self.list_jinja_extensions())
         env = jinja2.Environment(**kwargs)
         filters = (
             ('date', babel_dates.format_date),

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -1,4 +1,6 @@
+from grow.common import utils
 from grow.pods import pods
+from grow.pods import preprocessors
 from grow.pods import storage
 from grow.pods.controllers import static
 from grow.testing import testing
@@ -157,6 +159,20 @@ class PodTest(unittest.TestCase):
         with mock.patch.dict(self.pod.yaml, {'extensions': {'jinja2': ['invalid/path']}}):
             with self.assertRaises(pods.PodSpecParseError):
                 self.pod.list_jinja_extensions()
+
+    def test_list_preprocessors(self):
+        items = self.pod.list_preprocessors()
+        self.assertEqual(len(items), 1)
+        # see podspec.yaml in test pod
+        self.assertEqual(items[0].__class__.__name__, 'CustomPreprocessor')
+        self.assertTrue(isinstance(items[0], preprocessors.base.BasePreprocessor))
+        # Calling again should get the same results (list is refreshed on each
+        # call, so want to make sure it isn't extended with duplicates)
+        self.assertEqual(len(self.pod.list_preprocessors()), 1)
+
+    def test_custom_preprocessor(self):
+        self.pod.preprocess(['custom'])
+        self.assertEqual(self.pod._custom_preprocessor_value, 'testing123')
 
 
 if __name__ == '__main__':

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -2,6 +2,8 @@ from grow.pods import pods
 from grow.pods import storage
 from grow.pods.controllers import static
 from grow.testing import testing
+import jinja2
+import mock
 import os
 import unittest
 
@@ -142,6 +144,19 @@ class PodTest(unittest.TestCase):
         ]
         for item in items:
             self.assertIn(item, expected)
+
+    def test_list_jinja_extensions(self):
+        items = self.pod.list_jinja_extensions()
+        self.assertEqual(len(items), 1)
+        # Custom extension is called Triplicate (see podspec.yaml in test pod)
+        self.assertEqual(items[0].__name__, 'Triplicate')
+        self.assertTrue(issubclass(items[0], jinja2.ext.Extension))
+
+    def test_invalid_jinja_extension(self):
+        # Make sure an invalid jinja2 exensions config throws an error
+        with mock.patch.dict(self.pod.yaml, {'extensions': {'jinja2': ['invalid/path']}}):
+            with self.assertRaises(pods.PodSpecParseError):
+                self.pod.list_jinja_extensions()
 
 
 if __name__ == '__main__':

--- a/grow/pods/preprocessors/preprocessors.py
+++ b/grow/pods/preprocessors/preprocessors.py
@@ -1,3 +1,4 @@
+from grow.common import utils
 from grow.pods.preprocessors import google_drive
 from grow.pods.preprocessors import sass_preprocessor
 from protorpc import protojson
@@ -36,6 +37,12 @@ def make_preprocessor(kind, config, pod):
 def register_builtins():
     for builtin in _builtins:
         register_preprocessor(builtin)
+
+
+def register_extensions(extension_paths, pod_root):
+    for path in extension_paths:
+        cls = utils.import_string(path, [pod_root])
+        register_preprocessor(cls)
 
 
 register_builtins()

--- a/grow/testing/testdata/pod/extensions/preprocessors.py
+++ b/grow/testing/testdata/pod/extensions/preprocessors.py
@@ -1,0 +1,13 @@
+from grow.pods.preprocessors import base
+from protorpc import messages
+
+
+class CustomPreprocessor(base.BasePreprocessor):
+    KIND = 'custom_preprocessor'
+
+    class Config(messages.Message):
+        value = messages.StringField(1)
+
+    def run(self):
+        # To allow the test to check the result
+        self.pod._custom_preprocessor_value = self.config.value

--- a/grow/testing/testdata/pod/extensions/preprocessors.py
+++ b/grow/testing/testdata/pod/extensions/preprocessors.py
@@ -1,8 +1,8 @@
-from grow.pods.preprocessors import base
+from grow import Preprocessor
 from protorpc import messages
 
 
-class CustomPreprocessor(base.BasePreprocessor):
+class CustomPreprocessor(Preprocessor):
     KIND = 'custom_preprocessor'
 
     class Config(messages.Message):

--- a/grow/testing/testdata/pod/extensions/triplicate.py
+++ b/grow/testing/testdata/pod/extensions/triplicate.py
@@ -1,0 +1,12 @@
+""" Example (but pointless) custom Jinja Extension """
+from jinja2.ext import Extension
+
+
+def triplicate(value):
+    return value + value + value
+
+
+class Triplicate(Extension):
+    def __init__(self, environment):
+        super(Triplicate, self).__init__(environment)
+        environment.filters['triplicate'] = triplicate

--- a/grow/testing/testdata/pod/podspec.yaml
+++ b/grow/testing/testdata/pod/podspec.yaml
@@ -52,3 +52,7 @@ deployments:
     destination: scp
     host: localhost
     root_dir: dist/
+
+extensions:
+  jinja2:
+  - extensions.triplicate.Triplicate

--- a/grow/testing/testdata/pod/podspec.yaml
+++ b/grow/testing/testdata/pod/podspec.yaml
@@ -53,6 +53,13 @@ deployments:
     host: localhost
     root_dir: dist/
 
+preprocessors:
+- name: custom
+  kind: custom_preprocessor
+  value: testing123
+
 extensions:
   jinja2:
   - extensions.triplicate.Triplicate
+  preprocessors:
+  - extensions.preprocessors.CustomPreprocessor

--- a/grow/testing/testdata/pod/views/home.html
+++ b/grow/testing/testdata/pod/views/home.html
@@ -14,6 +14,9 @@
     {% set static = g.static('/static/test.txt', locale=doc.locale) %}
     Localized: {{static}} - {{static.url.path}}
   </p>
+  <p>
+    Custom Jinja Extension: {{'abc'|triplicate}}
+  </p>
   <nav>
     {% for page in g.docs('pages') %}
       <li><a href="{{page.url.path}}">{{page.titles('nav')}}</a>


### PR DESCRIPTION
Repeat of #169, rebased & raised against `develop`.

---

Simple solution for #55. A slight variation on what I proposed there: decided it was easier & more explicit to separate jinja2 / preprocessors in podspec.yaml:

```yaml
extensions:
  jinja2:
  - path.to.CustomJinja2Extension
  preprocessors:
  - path.to.CustomPreprocessor
```

[See the example in grow/testing/testdata/pod/podspec.yaml](https://github.com/stucox/pygrow/blob/feature/extensions/grow/testing/testdata/pod/podspec.yaml#L54).

Custom Jinja2 filters would need to be wrapped in an extension class (i.e. a subclass of) — the tests I’ve written for this include an example of this. Could add syntax to allow filters to be declared directly in podspec.yaml (then added to the env via the `filters` arg) — maybe at a later date?

Happy to write some docs for this once merged — should that be a PR against https://github.com/grow/growsdk.org?

---

@jeremydw said:

> Great work on this and thank you for the contribution. :) The solution looks great from a quick glance.
>
> Before merging, I'm doing a tiny bit of research on naming and the syntax in podspec.yaml. Can you adjust the PR to be based off of develop instead of master? master is what's currently released.

Done.

> Also, before releasing this I'd like to perhaps iterate on the "public API" for writing extensions -- for example, it might be cleaner to allow import grow and then for the base class to be grow.Preprocessor (via an alias in the right place in \_\_init\_\_.py). This would basically be the first time the internal paths of the Python program have any implication on how folks construct sites.

I’ve added an alias as suggested — agree this makes sense to keep flexibility over internal structure.

Appreciate the Preprocessor class API might need refining too, but how about we leave this as-is, undocumented (or mark “experimental”) for now and try it out ourselves?

> Additionally (just as a reminder to myself) – need to test the behavior of the imports in the frozen/binary environment.

Ok sure, let me know if I can help.